### PR TITLE
Implement SpurResource class

### DIFF
--- a/spur/core/base.py
+++ b/spur/core/base.py
@@ -260,6 +260,7 @@ class SpurResource(Resource):
             and self._component.check_usage_eligibility(event.agent)
         ):
             self.users.append(event)
+            self._component.accept_agent(event.agent)
             event.usage_since = self._env.now
             event.succeed()
 
@@ -321,6 +322,10 @@ class Agent(BaseItem, ABC):
     @tour.setter
     def tour(self, tour):
         self._tour = tour
+
+    @property
+    def current_segment(self):
+        return self._current_segment
 
     def transfer_to(self, segment):
         # First we tell the previous component we're done

--- a/spur/core/base.py
+++ b/spur/core/base.py
@@ -156,7 +156,7 @@ class BaseComponent(BaseItem, ABC):
                     clean["args"][clean_k] = d[k]
         return clean
 
-    def check_usage_eligibility(self, agent: 'Agent'):
+    def can_accept_agent(self, agent: 'Agent') -> bool:
         """Check whether `agent` is eligible to use this component based on component state.
 
         Always returns True by default, meaning the decision to accept the agent's
@@ -257,7 +257,7 @@ class SpurResource(Resource):
     def _do_put(self, event: SpurRequest) -> None:
         if (
             len(self.users) < self.capacity
-            and self._component.check_usage_eligibility(event.agent)
+            and self._component.can_accept_agent(event.agent)
         ):
             self.users.append(event)
             self._component.accept_agent(event.agent)

--- a/spur/core/component.py
+++ b/spur/core/component.py
@@ -3,9 +3,7 @@
 import logging
 import math
 
-from simpy import Resource
-
-from spur.core.base import ResourceComponent
+from spur.core.base import ResourceComponent, SpurResource
 from spur.core.jitter import NoJitter
 
 from spur.core.exception import NotPositiveError
@@ -36,7 +34,7 @@ class TimedTrack(ResourceComponent):
     ) -> None:
 
         self.traversal_time = traversal_time
-        resource = Resource(model, capacity=capacity)
+        resource = SpurResource(model, self, capacity=capacity)
         super().__init__(model, uid, resource, jitter)
 
         self.simLog = logging.getLogger(f"sim.track.{self.__name__}.{self.uid}")
@@ -90,7 +88,7 @@ class PhysicsTrack(ResourceComponent):
     __name__ = "PhysicsTrack"
 
     def __init__(self, model, uid, length, track_speed, jitter=NoJitter()) -> None:
-        resource = Resource(model, capacity=1)
+        resource = SpurResource(model, self, capacity=1)
         self.track_speed = track_speed
         self.length = length
         super().__init__(model, uid, resource, jitter)
@@ -150,7 +148,7 @@ class SimpleYard(ResourceComponent):
     __name__ = "SimpleYard"
 
     def __init__(self, model, uid, capacity, jitter=NoJitter()) -> None:
-        resource = Resource(model, capacity=capacity)
+        resource = SpurResource(model, self, capacity=capacity)
         super().__init__(model, uid, resource, jitter)
         # Override the simulation logging information
         self.simLog = logging.getLogger(f"sim.track.{self.__name__}.{self.uid}")
@@ -195,7 +193,7 @@ class SimpleStation(ResourceComponent):
     def __init__(
         self, model, uid, mean_boarding, mean_alighting, jitter=NoJitter()
     ) -> None:
-        resource = Resource(model, capacity=1)
+        resource = SpurResource(model, self, capacity=1)
         super().__init__(model, uid, resource, jitter)
         self._mean_boarding = mean_boarding
         self._mean_alighting = mean_alighting
@@ -246,7 +244,7 @@ class TimedStation(ResourceComponent):
         traversal_time,
         jitter=NoJitter(),
     ) -> None:
-        resource = Resource(model, capacity=1)
+        resource = SpurResource(model, self, capacity=1)
         super().__init__(model, uid, resource, jitter)
         self._mean_boarding = mean_boarding
         self._mean_alighting = mean_alighting
@@ -294,7 +292,7 @@ class SimpleCrossover(ResourceComponent):
 
     def __init__(self, model, uid, traversal_time, jitter=NoJitter()) -> None:
         self.traversal_time = traversal_time
-        resource = Resource(model, capacity=1)
+        resource = SpurResource(model, self, capacity=1)
         super().__init__(model, uid, resource, jitter)
 
     @property

--- a/spur/core/train.py
+++ b/spur/core/train.py
@@ -85,11 +85,11 @@ class Train(Agent):
                 self.simLog.debug(
                     "Not attached. Will try to access to first component."
                 )
-            # Ask to access the current component in the list
+            # Ask to access the upcoming segment component and accept train once successful
             req = segment.component.resource.request(self)
             yield req
 
-            # Transfer to the new segment
+            # Release train from old segment component and update current segment
             if self._current_segment:
                 self._current_segment.component.release_agent(self)
             self._current_segment = segment

--- a/spur/core/train.py
+++ b/spur/core/train.py
@@ -86,7 +86,7 @@ class Train(Agent):
                     "Not attached. Will try to access to first component."
                 )
             # Ask to access the current component in the list
-            req = segment.component.resource.request()
+            req = segment.component.resource.request(self)
             yield req
 
             # Transfer to the new segment

--- a/spur/core/train.py
+++ b/spur/core/train.py
@@ -90,7 +90,9 @@ class Train(Agent):
             yield req
 
             # Transfer to the new segment
-            self.transfer_to(segment)
+            if self._current_segment:
+                self._current_segment.component.release_agent(self)
+            self._current_segment = segment
             # Release the previous segment's resource once train is in the new segment
             if prev_req is not None:
                 segment.prev.component.resource.release(prev_req)


### PR DESCRIPTION
As per #58 

Additional changes:

- Added a custom `SpurRequest` class as well that inherits SimPy's `Request` class; this custom class also takes in the agent making the request, so that in the `_do_put()` method of `SpurResource`, the associated component's `check_usage_eligibility()` method could be called with the specific agent.
- The `accept_agent()` method is now called directly within the `_do_put()` method, such that if the request is successful, the agent is added into both the resource's list of users and also the component's own data structures as well; this synchronized update eliminates event ordering issues arising from concurrency.
- Related to the above, `release_agent()` is now invoked in the main tour traversal loop of the `Train` class, instead of being part of the `transfer_to()` method.